### PR TITLE
Rename to paragon_shops and purple UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# ef-shops
+# paragon_shops
 A shops system made in React for es_extended and ox_inventory
 
-![FiveM_b2944_GTAProcess - April22 - 03 01 - 3496](https://github.com/jellyton69/ef_shops/assets/20498875/38df9b9b-8e3a-49e5-a12f-04f56d6fa132)
+![FiveM_b2944_GTAProcess - April22 - 03 01 - 3496](https://github.com/jellyton69/paragon_shops/assets/20498875/38df9b9b-8e3a-49e5-a12f-04f56d6fa132)
 
 # Features
 - Client-side purchase validation (cash/card/weight/stock) + server-side security checks

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -113,7 +113,7 @@ local function openShop(data)
 
 	setShopVisible(true)
 
-        local shopItems = lib.callback.await("EF-Shops:Server:OpenShop", false, data.type, data.location)
+        local shopItems = lib.callback.await("Paragon-Shops:Server:OpenShop", false, data.type, data.location)
 
         if not shopItems then
 		lib.print.error("Failed opening shop: " .. data.type)
@@ -131,7 +131,7 @@ local function openShop(data)
 		item.jobs = productData.jobs
         end
 
-        societyMoney = lib.callback.await('EF-Shops:Server:GetSocietyMoney', false)
+        societyMoney = lib.callback.await('Paragon-Shops:Server:GetSocietyMoney', false)
 
         UpdatePlayerData()
 
@@ -189,7 +189,7 @@ RegisterNuiCallback("purchaseItems", function(data, cb)
                 return
         end
 
-	local success = lib.callback.await("EF-Shops:Server:PurchaseItems", false, data)
+    local success = lib.callback.await("Paragon-Shops:Server:PurchaseItems", false, data)
 
         if not success then
                 lib.notify({ title = "Kauf fehlgeschlagen", description = "Beim Kauf ist ein Fehler aufgetreten.", type = "error" })
@@ -463,8 +463,8 @@ AddEventHandler('ox_inventory:updateInventory', function()
 	})
 end)
 
-RegisterNetEvent('EF-Shops:Client:SetSocietyMoney')
-AddEventHandler('EF-Shops:Client:SetSocietyMoney', function(amount)
+RegisterNetEvent('Paragon-Shops:Client:SetSocietyMoney')
+AddEventHandler('Paragon-Shops:Client:SetSocietyMoney', function(amount)
     societyMoney = amount
     UpdateShopData()
 end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,7 +6,7 @@ author 'Jellyton'
 version '1.3.0'
 description 'Everfall shops system. Made with React.'
 license 'GPL-3.0'
-repository 'https://github.com/jellyton69/ef-shops'
+repository 'https://github.com/jellyton69/paragon_shops'
 
 lua54 'yes'
 

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -1,4 +1,4 @@
-lib.versionCheck('jellyton69/ef-shops')
+lib.versionCheck('jellyton69/paragon_shops')
 if not lib.checkDependency('ox_lib', '3.0.0') then error() end
 if not lib.checkDependency('ox_inventory', '2.20.0') then error() end
 
@@ -49,7 +49,7 @@ local function registerShop(shopType, shopData)
 	end
 end
 
-lib.callback.register("EF-Shops:Server:OpenShop", function(source, shop_type, location)
+lib.callback.register("Paragon-Shops:Server:OpenShop", function(source, shop_type, location)
         local shop = ShopData[shop_type] and ShopData[shop_type][location]
         if not shop then
                 lib.print.error("Shop not found: " .. shop_type .. " at location " .. location)
@@ -58,7 +58,7 @@ lib.callback.register("EF-Shops:Server:OpenShop", function(source, shop_type, lo
         return shop.inventory
 end)
 
-lib.callback.register("EF-Shops:Server:GetSocietyMoney", function(source)
+lib.callback.register("Paragon-Shops:Server:GetSocietyMoney", function(source)
         local xPlayer = ESX.GetPlayerFromId(source)
         if not xPlayer then return 0 end
 
@@ -79,14 +79,14 @@ local mapBySubfield = function(tbl, subfield)
 	return mapped
 end
 
-lib.callback.register("EF-Shops:Server:PurchaseItems", function(source, purchaseData)
+lib.callback.register("Paragon-Shops:Server:PurchaseItems", function(source, purchaseData)
 	if not purchaseData then
-		lib.print.warn(GetPlayerName(source) .. " may be attempting to exploit EF-Shops:Server:PurchaseItems.")
+            lib.print.warn(GetPlayerName(source) .. " may be attempting to exploit Paragon-Shops:Server:PurchaseItems.")
 		return false
 	end
 
 	if not purchaseData.shop then
-		lib.print.warn(GetPlayerName(source) .. " may be attempting to exploit EF-Shops:Server:PurchaseItems.")
+            lib.print.warn(GetPlayerName(source) .. " may be attempting to exploit Paragon-Shops:Server:PurchaseItems.")
 		lib.print.warn(purchaseData)
 		return false
 	end
@@ -248,7 +248,7 @@ lib.callback.register("EF-Shops:Server:PurchaseItems", function(source, purchase
                 end
 
                 account.removeMoney(totalPrice)
-                TriggerClientEvent('EF-Shops:Client:SetSocietyMoney', source, account.money)
+                TriggerClientEvent('Paragon-Shops:Client:SetSocietyMoney', source, account.money)
         else
                 lib.print.error("Invalid currency type used in purchase: " .. tostring(currency))
                 return false
@@ -349,5 +349,5 @@ AddEventHandler('onResourceStart', function(resource)
 		::continue::
 	end
 	
-	lib.print.info("EF-Shops loaded successfully with " .. lib.table.tablesize(ShopData) .. " shop types")
+        lib.print.info("Paragon-Shops loaded successfully with " .. lib.table.tablesize(ShopData) .. " shop types")
 end)

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>EF Shops</title>
+                <title>Paragon Shops</title>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -13,13 +13,13 @@
 		--card-foreground: 240 10% 3.9%;
 		--popover: 0 0% 100%;
 		--popover-foreground: 240 10% 3.9%;
-		--primary: 240 5.9% 10%;
+                --primary: 270 50% 50%;
 		--primary-foreground: 0 0% 98%;
 		--secondary: 240 4.8% 95.9%;
 		--secondary-foreground: 240 5.9% 10%;
 		--muted: 240 4.8% 95.9%;
 		--muted-foreground: 240 3.8% 46.1%;
-		--accent: 240 4.8% 95.9%;
+                --accent: 270 60% 85%;
 		--accent-foreground: 240 5.9% 10%;
 		--destructive: 0 72.22% 50.59%;
 		--destructive-foreground: 0 0% 98%;
@@ -34,17 +34,17 @@
 		--chart-4: 43 74% 66%;
 		--chart-5: 27 87% 67%;
 
-		--color-everfall-50: 193 194 197;
-		--color-everfall-100: 166 167 171;
-		--color-everfall-200: 144 146 150;
-		--color-everfall-300: 92 95 102;
-		--color-everfall-400: 55 58 64;
-		--color-everfall-500: 44 46 51;
-		--color-everfall-600: 40 41 44;
-		--color-everfall-650: 36 37 40;
-		--color-everfall-700: 25 25 26;
-		--color-everfall-800: 18 19 19;
-		--color-everfall-900: 9 9 9;
+                --color-everfall-50: 250 245 255;
+                --color-everfall-100: 243 232 255;
+                --color-everfall-200: 233 213 255;
+                --color-everfall-300: 216 180 254;
+                --color-everfall-400: 192 132 252;
+                --color-everfall-500: 168 85 247;
+                --color-everfall-600: 147 51 234;
+                --color-everfall-650: 135 37 217;
+                --color-everfall-700: 126 34 206;
+                --color-everfall-800: 107 33 168;
+                --color-everfall-900: 59 7 100;
 	}
 
 	.dark {
@@ -54,14 +54,14 @@
 		--card-foreground: 0 0% 98%;
 		--popover: 240 10% 3.9%;
 		--popover-foreground: 0 0% 98%;
-		--primary: 0 0% 98%;
-		--primary-foreground: 240 5.9% 10%;
+                --primary: 270 60% 60%;
+                --primary-foreground: 0 0% 98%;
 		--secondary: 240 3.7% 15.9%;
 		--secondary-foreground: 0 0% 98%;
 		--muted: 240 3.7% 15.9%;
 		--muted-foreground: 240 5% 64.9%;
-		--accent: 240 3.7% 15.9%;
-		--accent-foreground: 0 0% 98%;
+                --accent: 270 40% 30%;
+                --accent-foreground: 0 0% 98%;
 		--destructive: 0 62.8% 30.6%;
 		--destructive-foreground: 0 85.7% 97.3%;
 		--border: 240 3.7% 15.9%;


### PR DESCRIPTION
## Summary
- rename resource references from `ef-shops` to `paragon_shops`
- retheme UI with purple colours

## Testing
- `npm install --ignore-scripts` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6865c56b3c0883308bb98056b252b065