### PR TITLE
Restrict society purchases to specified jobs

### DIFF
--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -131,7 +131,7 @@ local function openShop(data)
 		item.jobs = productData.jobs
         end
 
-        societyMoney = lib.callback.await('Paragon-Shops:Server:GetSocietyMoney', false)
+        societyMoney = lib.callback.await('Paragon-Shops:Server:GetSocietyMoney', false, data.type)
 
         UpdatePlayerData()
 

--- a/config/locations.lua
+++ b/config/locations.lua
@@ -5,7 +5,7 @@
 ---@field shopItems string which table to pull shop items from
 ---@field blip? { sprite: number, color: number, scale?: number, disabled: boolean } blip data for the shop
 ---@field jobs? table<string, number> map of group names to min grade required to access the shop
----@field societyGrade? number minimum job grade to pay with society money
+---@field societies? table<string, number | string> society names mapped to required rank to pay with society funds
 ---@field target? { label?: string, radius?: number, icon?: string } target data for the shop
 
 ---@type table<string, ShopLocation>
@@ -87,7 +87,9 @@ return {
 	-- Hardware Store Locations
         hardware = {
                 label = "Hardware Store",
-                societyGrade = 1,
+                societies = {
+                        mechanic = 1
+                },
                 model = {
 			`s_m_m_autoshop_02`,
 			`S_F_M_Autoshop_01`,
@@ -116,7 +118,9 @@ return {
 	-- Ammunation Locations
         ammunation = {
                 label = "Ammunation",
-                societyGrade = 2,
+                societies = {
+                        police = 2
+                },
                 target = { label = "Ammunation öffnen" },
 		model = {
 			`S_M_M_AmmuCountry`,


### PR DESCRIPTION
## Summary
- configure allowed societies per location
- adapt client/server callbacks for society money
- validate rank when paying with society funds

## Testing
- `luac -p server/sv_main.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d284df1083308498df0905689048