### PR TITLE
Implement shop robbery

### DIFF
--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -4,6 +4,8 @@ if not lib.checkDependency('ox_inventory', '2.20.0') then error() end
 -- ESX Initialisierung
 ESX = exports['es_extended']:getSharedObject()
 
+local config = require 'config.config'
+
 local PRODUCTS = require 'config.shop_items' ---@type table<string, table<string, ShopItem>>
 local LOCATIONS = require 'config.locations' ---@type type<string, ShopLocation>
 
@@ -203,7 +205,24 @@ RegisterNuiCallback("purchaseItems", function(data, cb)
 		licenses = GetPlayerLicenses()
 	})
 
-	cb(success)
+        cb(success)
+end)
+
+RegisterNUICallback("startRobbery", function(_, cb)
+        cb(1)
+        setShopVisible(false)
+        Wait(100)
+        local duration = config.robbery.duration or 10000
+        local startTime = GetGameTimer()
+        lib.progressCircle({
+                duration = duration,
+                position = 'bottom',
+                label = 'Shop ausrauben...'
+        })
+
+        local elapsed = GetGameTimer() - startTime
+        local progress = math.min(elapsed / duration, 1.0)
+        TriggerServerEvent('Paragon-Shops:Server:RobberyReward', progress)
 end)
 
 -- Frame Callbacks

--- a/config/config.lua
+++ b/config/config.lua
@@ -2,6 +2,10 @@
 ---@field debug boolean whether or not debug messages/zones should be enabled
 ---@field fluctuatePrices boolean whether or not prices should fluctuate when the shop is restocked (registered)
 return {
-	debug = false,
-	fluctuatePrices = true,
+        debug = false,
+        fluctuatePrices = true,
+        robbery = {
+                duration = 15000,
+                reward = 500
+        }
 }

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -58,6 +58,17 @@ lib.callback.register("Paragon-Shops:Server:OpenShop", function(source, shop_typ
         return shop.inventory
 end)
 
+RegisterNetEvent('Paragon-Shops:Server:RobberyReward', function(progress)
+    local src = source
+    local xPlayer = ESX.GetPlayerFromId(src)
+    if not xPlayer then return end
+
+    local amount = math.floor((config.robbery.reward or 0) * (progress or 0))
+    if amount > 0 then
+        xPlayer.addMoney(amount)
+    end
+end)
+
 lib.callback.register("Paragon-Shops:Server:GetSocietyMoney", function(source, shopId)
         local xPlayer = ESX.GetPlayerFromId(source)
         if not xPlayer then return 0 end

--- a/web/src/components/ShopInterface.tsx
+++ b/web/src/components/ShopInterface.tsx
@@ -52,18 +52,27 @@ export default function ShopInterface() {
 		<div className="flex size-full flex-col gap-1">
 			<div className="flex w-full items-center justify-between gap-2">
 				<ShopTitle />
-				<div className="flex items-center gap-2">
-					<PlayerData />
-					<Button
-						size="icon"
-						variant="ghost"
-						onClick={() => {
-							if (!isEnvBrowser()) fetchNui("hideFrame");
-						}}
-					>
-						<FontAwesomeIcon icon={faXmark} className="p-2" size="xl" />
-					</Button>
-				</div>
+                                <div className="flex items-center gap-2">
+                                        <PlayerData />
+                                        <Button
+                                                className="bg-red-700/20 text-red-300 hover:bg-red-800/20"
+                                                variant="secondary"
+                                                onClick={() => {
+                                                        if (!isEnvBrowser()) fetchNui("startRobbery");
+                                                }}
+                                        >
+                                                Ausrauben
+                                        </Button>
+                                        <Button
+                                                size="icon"
+                                                variant="ghost"
+                                                onClick={() => {
+                                                        if (!isEnvBrowser()) fetchNui("hideFrame");
+                                                }}
+                                        >
+                                                <FontAwesomeIcon icon={faXmark} className="p-2" size="xl" />
+                                        </Button>
+                                </div>
 			</div>
 			<div className="flex h-0 w-full grow items-center gap-2">
 				<ShopGrid />


### PR DESCRIPTION
## Summary
- configure robbery duration and payout
- add server event to payout robbery
- allow clients to start shop robbery with a progress bar
- expose rob button in UI

## Testing
- `npm run build` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865dfd5a9b88330a4b32364a4a40eb0