### PR TITLE
Add police dispatch chance for robberies

### DIFF
--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -189,6 +189,7 @@ exports("OpenShop", function(type)
 	openShop({ type = type })
 end)
 
+
 RegisterNuiCallback("purchaseItems", function(data, cb)
         if not data then
                 lib.notify({ title = "Kauf fehlgeschlagen", description = "Beim Kauf ist ein Fehler aufgetreten.", type = "error" })
@@ -221,6 +222,8 @@ RegisterNUICallback("startRobbery", function(_, cb)
         end
 
         if not CurrentShop then return end
+
+        TriggerServerEvent('Paragon-Shops:Server:RobberyStarted', CurrentShop.id, CurrentShop.location)
 
         setShopVisible(false)
         Wait(100)
@@ -542,5 +545,17 @@ AddEventHandler('onResourceStop', function(resource)
 	end
 
 	-- Text-UI verstecken beim Resource-Stop
-	HideShopText()
+        HideShopText()
+end)
+
+RegisterNetEvent('Paragon-Shops:Client:PoliceDispatch')
+AddEventHandler('Paragon-Shops:Client:PoliceDispatch', function(coords)
+    if ESX.PlayerData.job and ESX.PlayerData.job.name == 'police' then
+        local street = GetStreetNameFromHashKey(GetStreetNameAtCoord(coords.x, coords.y, coords.z))
+        lib.notify({
+            title = 'Ladenüberfall',
+            description = ('Ein Shop wird überfallen in der Nähe von %s'):format(street),
+            type = 'inform'
+        })
+    end
 end)

--- a/config/config.lua
+++ b/config/config.lua
@@ -9,6 +9,7 @@ return {
                 reward = 500,
                 cooldown = 300000,
                 maxDistance = 20.0,
-                abortControl = 47
+                abortControl = 47,
+                dispatchChance = 0.5 -- 50% chance police gets a dispatch on robbery start
         }
 }

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -9,6 +9,17 @@ local config = require 'config.config'
 
 local lastRobbery = {}
 
+---Dispatch helper
+---@param coords vector3
+local function sendPoliceDispatch(coords)
+    for _, playerId in ipairs(GetPlayers()) do
+        local xPlayer = ESX.GetPlayerFromId(playerId)
+        if xPlayer and xPlayer.job and xPlayer.job.name == 'police' then
+            TriggerClientEvent('Paragon-Shops:Client:PoliceDispatch', playerId, coords)
+        end
+    end
+end
+
 local ox_inventory = exports.ox_inventory
 local ITEMS = ox_inventory:Items()
 
@@ -58,6 +69,16 @@ lib.callback.register("Paragon-Shops:Server:OpenShop", function(source, shop_typ
                 return nil
         end
         return shop.inventory
+end)
+
+RegisterNetEvent('Paragon-Shops:Server:RobberyStarted', function(shopId, location)
+    local shopData = LOCATIONS[shopId]
+    if not shopData or not shopData.coords or not shopData.coords[location] then return end
+
+    if math.random() < (config.robbery.dispatchChance or 0) then
+        local coords = shopData.coords[location]
+        sendPoliceDispatch(vector3(coords.x, coords.y, coords.z))
+    end
 end)
 
 RegisterNetEvent('Paragon-Shops:Server:RobberyReward', function(progress)


### PR DESCRIPTION
## Summary
- add dispatchChance config option
- notify police about robberies when chance succeeds

## Testing
- `npm run build` *(fails: missing packages due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68664be373048330b744f5ab97d57622