### PR TITLE
Add robbery progress bar and persistent cooldown

### DIFF
--- a/config/config.lua
+++ b/config/config.lua
@@ -10,6 +10,7 @@ return {
                 cooldown = 300000,
                 maxDistance = 20.0,
                 abortControl = 47,
-                dispatchChance = 0.5 -- 50% chance police gets a dispatch on robbery start
+                dispatchChance = 0.5, -- 50% chance police gets a dispatch on robbery start
+                progressLabel = 'Raub läuft...'
         }
 }


### PR DESCRIPTION
## Summary
- show robbery progress bar with `lib.progressCircle`
- store robbery cooldown using resource KVP
- fetch cooldown from server on player load and start robbery
- expose callback to get remaining cooldown
- add configurable progress label

## Testing
- `npm run build` *(fails: Cannot find module '@fortawesome/free-solid-svg-icons', '@fortawesome/react-fontawesome', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68664ea6f360833082a362a18ad3474a