### PR TITLE
Add separate buy-only and sell-only shops

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A shops system made in React for es_extended and ox_inventory
 - Sell multiple items at once with a single request
 - Price fluctuation
 - Hooks - handle post item purchases (example: registering weapons automatically in your MDT)
+- Separate shop types for buying and selling
 - Vendors can be peds or objects
 - Responsive UI
 - Job (can specify certain grades) lock specific shop types

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -167,7 +167,9 @@ local function openShop(data)
 		licenses = GetPlayerLicenses()
 	})
         CurrentShop = { id = data.type, location = data.location }
-        SendReactMessage("setCurrentShop", { id = data.type, location = data.location, label = LOCATIONS[data.type].label })
+        local canBuy = shopData.shopItems ~= nil
+        local canSell = shopData.sellItems ~= nil and shopData.sellItems ~= false
+        SendReactMessage("setCurrentShop", { id = data.type, location = data.location, label = LOCATIONS[data.type].label, canBuy = canBuy, canSell = canSell })
         SendReactMessage("setShopItems", shopItems)
 end
 

--- a/config/locations.lua
+++ b/config/locations.lua
@@ -153,25 +153,41 @@ return {
                         color = 1,
                 }
        },
-	digitalden = {
-		label = "Digital Den",
-		model = {
-			`S_M_M_LifeInvad_01`,
-			`IG_Ramp_Hipster`,
-			`A_M_Y_Hipster_02`,
-			`A_F_Y_Hipster_01`,
-			`IG_LifeInvad_01`,
-			`IG_LifeInvad_02`,
-			`CS_LifeInvad_01`,
-		},
-		coords = {
-			vector4(240.05, -897.57, 29.62, 159.74)
-		},
+       digitalden = {
+               label = "Digital Den",
+               model = {
+                       `S_M_M_LifeInvad_01`,
+                       `IG_Ramp_Hipster`,
+                       `A_M_Y_Hipster_02`,
+                       `A_F_Y_Hipster_01`,
+                       `IG_LifeInvad_01`,
+                       `IG_LifeInvad_02`,
+                       `CS_LifeInvad_01`,
+               },
+               coords = {
+                       vector4(240.05, -897.57, 29.62, 159.74)
+               },
+               shopItems = "electronics",
+               sellItems = { 'phone', 'radio' },
+               blip = {
+                       sprite = 606,
+                       color = 7,
+               }
+       },
+
+       buyonly = {
+                label = "Buy Only Shop",
+                coords = {
+                        vector4(250.0, -500.0, 28.0, 0.0)
+                },
                 shopItems = "electronics",
-                sellItems = { 'phone', 'radio' },
-                blip = {
-                        sprite = 606,
-                        color = 7,
-                }
+       },
+
+       sellonly = {
+                label = "Sell Only Shop",
+                coords = {
+                        vector4(260.0, -500.0, 28.0, 0.0)
+                },
+                sellItems = { 'phone', 'radio', 'lockpick' },
        },
 }

--- a/web/src/components/ShopInterface.tsx
+++ b/web/src/components/ShopInterface.tsx
@@ -50,24 +50,27 @@ function PlayerData() {
 
 export default function ShopInterface() {
         const { SellingMode, setSellingMode, CurrentShop } = useStoreShop();
+        const showToggle = CurrentShop?.canBuy && CurrentShop?.canSell;
         return (
                 <div className="flex size-full flex-col gap-1">
                         <div className="flex w-full items-center justify-between gap-2">
                                 <ShopTitle />
                                 <div className="flex items-center gap-2">
                                         <PlayerData />
-                                        <Button
-                                                className="bg-indigo-700/20 text-indigo-300 hover:bg-indigo-800/20"
-                                                variant="secondary"
-                                                onClick={() => {
-                                                        if (!SellingMode) {
-                                                                fetchNui("getInventory", { shop: CurrentShop?.id });
-                                                        }
-                                                        setSellingMode(!SellingMode);
-                                                }}
-                                        >
-                                                {SellingMode ? "Kaufen" : "Verkaufen"}
-                                        </Button>
+                                        {showToggle && (
+                                                <Button
+                                                        className="bg-indigo-700/20 text-indigo-300 hover:bg-indigo-800/20"
+                                                        variant="secondary"
+                                                        onClick={() => {
+                                                                if (!SellingMode) {
+                                                                        fetchNui("getInventory", { shop: CurrentShop?.id });
+                                                                }
+                                                                setSellingMode(!SellingMode);
+                                                        }}
+                                                >
+                                                        {SellingMode ? "Kaufen" : "Verkaufen"}
+                                                </Button>
+                                        )}
                                         <Button
                                                 className="bg-red-700/20 text-red-300 hover:bg-red-800/20"
                                                 variant="secondary"

--- a/web/src/stores/ShopStore.ts
+++ b/web/src/stores/ShopStore.ts
@@ -41,11 +41,12 @@ export const useStoreShop = create<ShopItems>((set, get) => ({
         cartValue: 0,
         sellCartValue: 0,
 
-	setCurrentShop: (shop: Shop) => {
-		set(() => ({
-			CurrentShop: shop,
-		}));
-	},
+        setCurrentShop: (shop: Shop) => {
+                set(() => ({
+                        CurrentShop: shop,
+                        SellingMode: shop.canBuy ? false : true,
+                }));
+        },
 
         setShopItems: (items: ShopItem[]) => {
                 const categorizedItems: Record<string, ShopItem[]> = {};

--- a/web/src/types/ShopItem.ts
+++ b/web/src/types/ShopItem.ts
@@ -1,7 +1,9 @@
 export type Shop = {
-	id: string;
-	location: number;
-	label: string;
+        id: string;
+        location: number;
+        label: string;
+        canBuy?: boolean;
+        canSell?: boolean;
 };
 
 export type ShopItem = {


### PR DESCRIPTION
## Summary
- allow shops to omit `shopItems` or `sellItems`
- send shop capabilities to UI
- toggle button only appears when both buy & sell are allowed
- start UI in sell mode for sell-only shops
- add example buy-only and sell-only locations
- document separate shop types in README

## Testing
- `npm install --silent` within `web`
- `npm run build --silent`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6867dc2cc24c8330ad2c00b580fe41a6