### PR TITLE
Update robbery logic and shop UI

### DIFF
--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -281,7 +281,8 @@ end)
 
 RegisterNUICallback("startRobbery", function(_, cb)
         cb(1)
-        local remain = lib.callback.await('Paragon-Shops:Server:GetRobberyCooldown', false)
+        if not CurrentShop then return end
+        local remain = lib.callback.await('Paragon-Shops:Server:GetRobberyCooldown', false, CurrentShop.id, CurrentShop.location)
         if remain and remain > 0 then
                 robberyCooldown = GetGameTimer() + remain
         end
@@ -291,8 +292,6 @@ RegisterNUICallback("startRobbery", function(_, cb)
                 lib.notify({ description = ('Du musst noch %s Sekunden warten.'):format(r), type = 'error' })
                 return
         end
-
-        if not CurrentShop then return end
 
         TriggerServerEvent('Paragon-Shops:Server:RobberyStarted', CurrentShop.id, CurrentShop.location)
 
@@ -344,7 +343,7 @@ RegisterNUICallback("startRobbery", function(_, cb)
         if aborted then
                 lib.notify({ description = 'Raub abgebrochen', type = 'error' })
         end
-        TriggerServerEvent('Paragon-Shops:Server:RobberyReward', progress)
+        TriggerServerEvent('Paragon-Shops:Server:RobberyReward', progress, CurrentShop.id, CurrentShop.location)
         robberyCooldown = GetGameTimer() + (config.robbery.cooldown or 60000)
 end)
 
@@ -526,10 +525,7 @@ RegisterNetEvent('esx:playerLoaded')
 AddEventHandler('esx:playerLoaded', function(xPlayer)
     ESX.PlayerData = xPlayer
     UpdateShopData()
-    local remain = lib.callback.await('Paragon-Shops:Server:GetRobberyCooldown', false)
-    if remain and remain > 0 then
-        robberyCooldown = GetGameTimer() + remain
-    end
+    robberyCooldown = 0
 end)
 
 RegisterNetEvent('esx:setJob')

--- a/web/src/components/ShopInterface.tsx
+++ b/web/src/components/ShopInterface.tsx
@@ -26,9 +26,11 @@ function ShopTitle() {
 }
 
 function PlayerData() {
-	const { Money } = useStoreSelf();
+        const { Money } = useStoreSelf();
+        const { CurrentShop } = useStoreShop();
 
-	if (!PlayerData) return null;
+        if (!CurrentShop?.canBuy) return null;
+        if (!Money) return null;
 
         return (
                 <div className="flex gap-2">
@@ -75,15 +77,17 @@ export default function ShopInterface() {
                                                         {SellingMode ? "Kaufen" : "Verkaufen"}
                                                 </Button>
                                         )}
-                                        <Button
-                                                className="bg-red-700/20 text-red-300 hover:bg-red-800/20"
-                                                variant="secondary"
-                                                onClick={() => {
-                                                        if (!isEnvBrowser()) fetchNui("startRobbery");
-                                                }}
-                                        >
-                                                Ausrauben
-                                        </Button>
+                                        {canBuy && (
+                                                <Button
+                                                        className="bg-red-700/20 text-red-300 hover:bg-red-800/20"
+                                                        variant="secondary"
+                                                        onClick={() => {
+                                                                if (!isEnvBrowser()) fetchNui("startRobbery");
+                                                        }}
+                                                >
+                                                        Ausrauben
+                                                </Button>
+                                        )}
                                         <Button
                                                 size="icon"
                                                 variant="ghost"


### PR DESCRIPTION
## Summary
- track robbery cooldown per shop
- adjust robbery callbacks for shop-specific cooldowns
- hide cash and robbery actions for sell-only shops

## Testing
- `npm run build` *(fails: Cannot find module 'react', '@radix-ui/react-tabs', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6867eb70c78483308d07c1d438eac232