### PR TITLE
Fix dependencies key in fxmanifest

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -33,6 +33,6 @@ files {
 	'web/build/**/*',
 }
 
-depedencies {
-	'ox_lib',
+dependencies {
+        'ox_lib',
 }


### PR DESCRIPTION
## Summary
- fix spelling of `dependencies` in manifest

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6868f49ce17c8330b72a0286b302bced